### PR TITLE
Prevent prompt to show directory-alias in zsh

### DIFF
--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -47,6 +47,7 @@ function jump() {
         sed 's#.*->  ##')
     if [[ -n "$target" ]]; then
         cd "$target"
+        unset target
         zle && zle redraw-prompt
     else
         zle redisplay # Just redisplay if no jump to do


### PR DESCRIPTION
This PR unsets the target-variable to prevent zsh from showing `~target` in the prompt instead of the full directory-name that was jumped to.

The behaviour above doesn't happen in the original version of fzf-marks but was probably introduced by your (useful!) recent improvements.